### PR TITLE
chore: add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/api_changes_report.md
+++ b/.github/ISSUE_TEMPLATE/api_changes_report.md
@@ -1,0 +1,46 @@
+---
+name: API Change Report
+about: Let us know if an upstream change to the API has occurred that needs to be triaged.
+labels: 'api change :up:'
+---
+
+# [API](https://docs.structurely.com) Change Report
+
+> Note: Whether our services are affected by the upstream change or not will greatly affect the speed of resolution. We welcome you to open a PR if you are able to.
+
+## What endpoint has changed
+
+- [ ] [Agents](https://docs.structurely.com/#agents)
+- [ ] [Leads](https://docs.structurely.com/#leads)
+- [ ] [Conversations](https://docs.structurely.com/#conversations)
+- [ ] [Conversation Webhooks](https://docs.structurely.com/#conversation-webhooks)
+- [ ] Other
+
+## Change information
+
+- [ ] Breaking change
+- [ ] Non-breaking change
+- [ ] A new endpoint has been added
+- [ ] Additional values are being returned by an endpoint
+
+>Note: [This is how we define a breaking vs non-breaking change](https://help.projectorpsa.com/display/AD/Breaking+vs+Non-Breaking+Changes)
+
+## Documentation
+
+If applicable, link us to an issue/PR on the [official documentation repo](https://github.com/structurely/datalayer-docs):
+
+<!-- structurely/datalayer-docs# -->
+
+If the change has been documented, please paste the link to the change on the live doc site or commit on their repo.
+
+If the change has not been documented, please give us as much information as possible on how to confirm the change for ourselves.
+
+Any of these would be very helpful:
+
+- cURL command or Postman/Hoppscotch/Paw snippet
+- Raw request output
+- Create a failing test case in our test suite
+
+## Additional context
+
+<!-- Let us know if you can open a PR to address this change or add anything else that may be important to know while triaging. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,24 @@
+---
+name: Bug report
+about: Create a report to help us fix a problem. Do not use this to report API changes.
+labels: 'bug :beetle:'
+---
+
+# Bug Report
+
+<!-- Bugs with reproduction cases are more likely to be solved, please include link to the repo here if applicable. -->
+
+## Describe the issue
+
+## Describe how you encountered the issue
+
+## Additional context
+
+<!-- Include anything else that may be helpful, like stack traces, error messages, HTTP headers, etc. -->
+
+### Environment
+
+- Gem Version: `x.y.z`
+- Ruby Version: `x.y.z`
+- Rails Version: `x.y.z`
+  - Rails Environment: `(production|development|test)`

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,5 +1,5 @@
 ---
-name: Bug report
+name: Bug Report
 about: Create a report to help us fix a problem. Do not use this to report API changes.
 labels: 'bug :beetle:'
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,5 +1,5 @@
 ---
-name: Feature request
+name: Feature Request
 about: Suggest an idea for this project. Do not use this for bugs or API changes.
 labels: 'feature :sparkles:'
 ---
@@ -8,16 +8,22 @@ labels: 'feature :sparkles:'
 
 ## What are you trying to accomplish?
 
-<!-- What can you not do now, that you would like to do? -->
-
-## Do you have a suggested solution?
-
-<!-- A clear and concise description of what you want to happen either in technical terms or not. Add any considered drawbacks as well. -->
+<!-- Example: As a ____, I need ____, in order to ____, because ____. -->
 
 ## How are you working around this issue today?
 
 <!-- If you are using a work around right now to accomplish your goal, please let us know. -->
 
+## Suggested solution
+
+<!--
+  A clear and concise description of what you want to happen either in technical terms or not.
+  Add any considered drawbacks as well. If you go the extra mile and add the code yourself, we will be very grateful!
+-->
+
 ## Teachability, Documentation, Adoption, Migration Strategy
 
-<!-- If you can, explain how users will be able to use this. You could write this out in the same pattern as our documentation, or add a diagram/screenshot. -->
+<!--
+  If you can, explain how users will be able to use this. You could write this out in the same pattern as our
+  documentation (please!), include a diagram/screenshot, write psuedocode examples, or anything else that you think will be helpful.
+-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest an idea for this project. Do not use this for bugs or API changes.
+labels: 'feature :sparkles:'
+---
+
+# Feature Request
+
+## What are you trying to accomplish?
+
+<!-- What can you not do now, that you would like to do? -->
+
+## Do you have a suggested solution?
+
+<!-- A clear and concise description of what you want to happen either in technical terms or not. Add any considered drawbacks as well. -->
+
+## How are you working around this issue today?
+
+<!-- If you are using a work around right now to accomplish your goal, please let us know. -->
+
+## Teachability, Documentation, Adoption, Migration Strategy
+
+<!-- If you can, explain how users will be able to use this. You could write this out in the same pattern as our documentation, or add a diagram/screenshot. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,23 +1,23 @@
 # Type: <!-- Bug Fix|Chore|Feature|Documentation  -->
 
-## What is the purpose of this pull request?
-
-<!--
-  If it's a bug fix, make sure there is an open and active issue, then link it below. Otherwise this can be removed.
--->
-
-Fixes #
-
-## What changes did you make? (overview)
-
-<!-- Remove this section if not applicable -->
-
-## Is there anything you'd like reviewers to focus on?
-
-<!-- Remove this section if not applicable -->
-
 ## Checklist
 
 - [ ] I've added/updated tests for changes to source code
 - [ ] I've added/updated applicable documentation
 - [ ] Actions are passing
+
+## Description of changes
+
+<!--
+  Give an overview of what changes you made and why. Your PR will be closed if this is not filled out.
+  If this is a bug fix, make sure there is an open and active issue, that you link below.
+-->
+
+Fixes: #
+
+## Additional context
+
+<!--
+  Let us know if you have any questions, suggestion for focus of review, or any other context/information
+  that may be useful to a potential reviewer or someone who visits this change in the future.
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+# Type: <!-- Bug Fix|Chore|Feature|Documentation  -->
+
+## What is the purpose of this pull request?
+
+<!--
+  If it's a bug fix, make sure there is an open and active issue, then link it below. Otherwise this can be removed.
+-->
+
+Fixes #
+
+## What changes did you make? (overview)
+
+<!-- Remove this section if not applicable -->
+
+## Is there anything you'd like reviewers to focus on?
+
+<!-- Remove this section if not applicable -->
+
+## Checklist
+
+- [ ] I've added/updated tests for changes to source code
+- [ ] I've added/updated applicable documentation
+- [ ] Actions are passing


### PR DESCRIPTION
# Type: Chore

## Checklist

- [ ] I've added/updated tests for changes to source code
- [ ] I've added/updated applicable documentation
- [x] Actions are passing

## Description of changes

Add GitHub issue and PR templates to standardize the GitHub workflow for contributors.

## Additional context

I think these are not half bad (if I do say so myself 😉) if we want to potentially fine tune them here and then add to our other projects that are lacking templates, I think it would be worth any potential bike shedding.
